### PR TITLE
Add top-level init_json and init_yaml functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,11 @@ components:
 The SQLALchemy models file then becomes:
 ```python
 # models.py
-from yaml import load, Loader
-from sqlalchemy.ext.declarative import declarative_base
-from openapi_sqlalchemy import init_model_factory
+from openapi_sqlalchemy import init_yaml
 
+Base, model_factory = init_yaml('./examples/simple-example-spec.yml')
 
-Base = declarative_base()
-with open("example-spec.yml") as spec_file:
-    SPEC = load(spec_file, Loader=Loader)
-MODEL_FACTORY = init_model_factory(base=Base, spec=SPEC)
-
-
-Employee = MODEL_FACTORY(name="Employee")
+Employee = model_factory(name="Employee")
 
 ```
 

--- a/openapi_sqlalchemy/__init__.py
+++ b/openapi_sqlalchemy/__init__.py
@@ -4,6 +4,7 @@ import functools
 import typing
 
 import typing_extensions
+from sqlalchemy.ext.declarative import declarative_base
 
 from . import exceptions
 from . import model_factory as _model_factory
@@ -51,3 +52,71 @@ def init_model_factory(*, base: typing.Type, spec: types.Schema) -> ModelFactory
     cached_model_factories = functools.lru_cache(maxsize=None)(bound_model_factories)
 
     return cached_model_factories
+
+
+def init_json(spec_filename: str, *, base: typing.Type) -> typing.Tuple:
+    """
+    Create factory that generates SQLAlchemy models based on an OpenAPI specification
+    as a JSON file.
+
+    Args:
+        spec_filename: filename of an OpenAPI spec in JSON format
+        base: The declarative base for the models.
+
+    Returns:
+        A tuple (Base, model_factory), where:
+
+        Base: a SQLAlchemy declarative base class
+        model_factory: A factory that returns SQLAlchemy models derived from the
+                       base based on the OpenAPI specification.
+
+    """
+    # Most OpenAPI specs are YAML, so, for efficiency, we only import json if we
+    # need it:
+    import json
+
+    if base is None:
+        Base = declarative_base()
+
+    with open(spec_filename) as spec_file:
+        spec = json.load(spec_file, Loader=Loader)
+    model_factory = init_model_factory(base=Base, spec=spec)
+    return Base, model_factory
+
+
+def init_yaml(spec_filename: str, *, base: typing.Type = None) -> typing.Tuple:
+    """
+    Create factory that generates SQLAlchemy models based on an OpenAPI specification
+    as a YAML file.
+
+    Args:
+        spec_filename: filename of an OpenAPI spec in YAML format
+        base: (optional) The declarative base for the models.
+              If base=None, construct a new SQLAlchemy declarative base.
+
+    Returns:
+        A tuple (Base, model_factory), where:
+
+        Base: a SQLAlchemy declarative base class
+        model_factory: A factory that returns SQLAlchemy models derived from the
+                       base based on the OpenAPI specification.
+
+    """
+
+    try:
+        import yaml
+    except ImportError:
+        raise ImportError('Using init_yaml requires the pyyaml package. '
+                          'Try `pip install pyyaml`.'
+        )
+
+    if base is None:
+        Base = declarative_base()
+
+    with open(spec_filename) as spec_file:
+        spec = yaml.load(spec_file, Loader=yaml.Loader)
+    model_factory = init_model_factory(base=Base, spec=spec)
+    return Base, model_factory
+
+
+__all__ = ['init_model_factory', 'init_json', 'init_yaml']


### PR DESCRIPTION
These are convenience functions for the most common case: when the OpenAPI spec
is available as a local file. For user convenience this function also creates
and returns a new declarative base class.